### PR TITLE
Add PDF optimization page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-These python webapps made with streamlit as frontend are made to optimize uploads to Master faster. It consists of an app that creates text that is then used for a file name in order to categorize and one that crops pictures.
+These python webapps made with streamlit as frontend are made to optimize uploads to Master faster. It consists of an app that creates text that is then used for a file name in order to categorize and one that crops pictures. A new page lets you upload a PDF and download an optimized version for faster viewing and smaller file size.

--- a/pages/5_📄_PDF_Optimering.py
+++ b/pages/5_📄_PDF_Optimering.py
@@ -1,0 +1,36 @@
+import streamlit as st
+from io import BytesIO
+try:
+    from pypdf import PdfReader, PdfWriter
+except Exception as e:  # pragma: no cover - handled at runtime
+    PdfReader = None
+    PdfWriter = None
+
+st.set_page_config(page_title="PDF-optimalisering", page_icon=":page_facing_up:")
+
+st.markdown("# 📄 PDF-optimalisering")
+uploaded_file = st.file_uploader("Last opp en PDF-fil", type=["pdf"])
+
+if uploaded_file is not None:
+    if PdfReader is None:
+        st.error("Modulen 'pypdf' er ikke tilgjengelig. Kan ikke optimalisere PDF.")
+    else:
+        reader = PdfReader(uploaded_file)
+        writer = PdfWriter()
+        for page in reader.pages:
+            try:
+                page.compress_content_streams()
+            except Exception:
+                pass
+            writer.add_page(page)
+        writer.add_metadata(reader.metadata or {})
+        output = BytesIO()
+        writer.write(output)
+        output.seek(0)
+        st.success("PDF-en er optimalisert og klar for nedlasting.")
+        st.download_button(
+            label="Last ned optimalisert PDF",
+            data=output,
+            file_name=f"optimalisert_{uploaded_file.name}",
+            mime="application/pdf",
+        )

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ google-cloud-logging
 pillow
 pillow-heif
 openai
+pypdf


### PR DESCRIPTION
## Summary
- add a Streamlit page that optimizes uploaded PDFs and returns a smaller download
- document the new PDF optimization page and its dependency
- include pypdf in requirements

## Testing
- `python -m py_compile pages/5_📄_PDF_Optimering.py`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement pypdf)*

------
https://chatgpt.com/codex/tasks/task_e_68c7d196f3088333a5bdb1511bbe4bbc